### PR TITLE
Upgrade & Downgrade Count Input

### DIFF
--- a/fazor.fsproj
+++ b/fazor.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="src/helpers/Dir.fs" />
     <Compile Include="src/helpers/Connect.fs" />
     <Compile Include="src/helpers/Run.fs" />
+    <Compile Include="src/helpers/Input.fs" />
     <Compile Include="src/commands/Init.fs" />
     <Compile Include="src/commands/New.fs" />
     <Compile Include="src/commands/Upgrade.fs" />

--- a/src/helpers/Input.fs
+++ b/src/helpers/Input.fs
@@ -1,0 +1,12 @@
+namespace Fazor
+
+module Input =
+    open System
+
+    let userEnterCount max =
+        match Console.ReadLine() with
+        | "" -> max
+        | other ->
+            match Int32.TryParse other with
+            | (true, number) -> if number <= max then number else -1
+            | (false, _) -> -1

--- a/test/test.fsproj
+++ b/test/test.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="../src/helpers/Dir.fs" />
     <Compile Include="../src/helpers/Connect.fs" />
     <Compile Include="../src/helpers/Run.fs" />
+    <Compile Include="../src/helpers/Input.fs" />
     <Compile Include="../src/commands/Init.fs" />
     <Compile Include="../src/commands/New.fs" />
     <Compile Include="../src/commands/Upgrade.fs" />


### PR DESCRIPTION
Now when upgrading or downgrading, the user is prompted to provide a count for the number of migrations they want to run. If no count is supplied, the default maximum number of migrations is run.